### PR TITLE
Enable javadoc linting

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -348,7 +348,6 @@
                                 <configuration>
                                         <source>8</source>
 					<detectJavaApiLink>false</detectJavaApiLink>
-                                        <doclint>none</doclint>
                                 </configuration>
                         </plugin>
 		</plugins>


### PR DESCRIPTION
Currently, with the re-enabling of the javadoc linting, 1.8 has no warnings and 11 only has warnings and no errors. I think this is "good enough" to close #2.