### PR TITLE
Ensure we are using the log4j implementation that we think we are

### DIFF
--- a/oscar4-api/pom.xml
+++ b/oscar4-api/pom.xml
@@ -66,11 +66,20 @@
         <dependency>
             <groupId>com.google.guava</groupId>
             <artifactId>guava</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.slf4j</groupId>
-            <artifactId>slf4j-api</artifactId>
-        </dependency>
+       </dependency>
+       <dependency>
+            <groupId>org.apache.logging.log4j</groupId>
+            <artifactId>log4j-api</artifactId>
+       </dependency>
+       <dependency>
+            <groupId>org.apache.logging.log4j</groupId>
+            <artifactId>log4j-core</artifactId>
+       </dependency>
+       <dependency>
+            <groupId>org.apache.logging.log4j</groupId>
+            <artifactId>log4j-slf4j-impl</artifactId>
+       </dependency>
+
 
 
         <dependency>

--- a/oscar4-chemnamedict/pom.xml
+++ b/oscar4-chemnamedict/pom.xml
@@ -27,8 +27,16 @@
             <artifactId>xom</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.slf4j</groupId>
-            <artifactId>slf4j-api</artifactId>
+            <groupId>org.apache.logging.log4j</groupId>
+            <artifactId>log4j-api</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.logging.log4j</groupId>
+            <artifactId>log4j-core</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.logging.log4j</groupId>
+            <artifactId>log4j-slf4j-impl</artifactId>
         </dependency>
         <dependency>
             <groupId>junit</groupId>

--- a/oscar4-core/pom.xml
+++ b/oscar4-core/pom.xml
@@ -22,9 +22,18 @@
             <artifactId>commons-io</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.slf4j</groupId>
-            <artifactId>slf4j-api</artifactId>
+            <groupId>org.apache.logging.log4j</groupId>
+            <artifactId>log4j-api</artifactId>
         </dependency>
+        <dependency>
+            <groupId>org.apache.logging.log4j</groupId>
+            <artifactId>log4j-core</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.logging.log4j</groupId>
+            <artifactId>log4j-slf4j-impl</artifactId>
+        </dependency>
+
         <dependency>
         	<groupId>junit</groupId>
         	<artifactId>junit</artifactId>

--- a/oscar4-data/pom.xml
+++ b/oscar4-data/pom.xml
@@ -26,10 +26,18 @@
 			<groupId>net.sourceforge.jregex</groupId>
 			<artifactId>jregex</artifactId>
 		</dependency>
-		<dependency>
-			<groupId>org.slf4j</groupId>
-			<artifactId>slf4j-api</artifactId>
-		</dependency>
+                <dependency>
+                        <groupId>org.apache.logging.log4j</groupId>
+                        <artifactId>log4j-api</artifactId>
+                </dependency>
+                <dependency>
+                        <groupId>org.apache.logging.log4j</groupId>
+                        <artifactId>log4j-core</artifactId>
+                </dependency>
+                <dependency>
+                        <groupId>org.apache.logging.log4j</groupId>
+                        <artifactId>log4j-slf4j-impl</artifactId>
+                </dependency>
                 <dependency>
                         <groupId>xom</groupId>
                         <artifactId>xom</artifactId>

--- a/oscar4-memmrecogniser-train/pom.xml
+++ b/oscar4-memmrecogniser-train/pom.xml
@@ -41,8 +41,16 @@
             <artifactId>commons-io</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.slf4j</groupId>
-            <artifactId>slf4j-api</artifactId>
+            <groupId>org.apache.logging.log4j</groupId>
+            <artifactId>log4j-api</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.logging.log4j</groupId>
+            <artifactId>log4j-core</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.logging.log4j</groupId>
+            <artifactId>log4j-slf4j-impl</artifactId>
         </dependency>
         <dependency>
             <groupId>xom</groupId>

--- a/oscar4-memmrecogniser/pom.xml
+++ b/oscar4-memmrecogniser/pom.xml
@@ -42,8 +42,16 @@
             <artifactId>guava</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.slf4j</groupId>
-            <artifactId>slf4j-api</artifactId>
+           <groupId>org.apache.logging.log4j</groupId>
+           <artifactId>log4j-api</artifactId>
+        </dependency>
+        <dependency>
+           <groupId>org.apache.logging.log4j</groupId>
+           <artifactId>log4j-core</artifactId>
+        </dependency>
+        <dependency>
+           <groupId>org.apache.logging.log4j</groupId>
+           <artifactId>log4j-slf4j-impl</artifactId>
         </dependency>
 		<dependency>
 			<groupId>org.apache.opennlp</groupId>

--- a/oscar4-obo/pom.xml
+++ b/oscar4-obo/pom.xml
@@ -22,11 +22,21 @@
             <groupId>uk.ac.cam.ch.wwmm.oscar</groupId>
             <artifactId>oscar4-chemnamedict</artifactId>
         </dependency>
-
         <dependency>
-            <groupId>org.slf4j</groupId>
-            <artifactId>slf4j-api</artifactId>
+            <groupId>org.apache.logging.log4j</groupId>
+            <artifactId>log4j-api</artifactId>
         </dependency>
+        <dependency>
+            <groupId>org.apache.logging.log4j</groupId>
+            <artifactId>log4j-core</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.logging.log4j</groupId>
+            <artifactId>log4j-slf4j-impl</artifactId>
+        </dependency>
+
+
+
         <dependency>
             <groupId>com.google.guava</groupId>
             <artifactId>guava</artifactId>

--- a/oscar4-recogniser-core/pom.xml
+++ b/oscar4-recogniser-core/pom.xml
@@ -43,8 +43,16 @@
             <artifactId>commons-io</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.slf4j</groupId>
-            <artifactId>slf4j-api</artifactId>
+            <groupId>org.apache.logging.log4j</groupId>
+            <artifactId>log4j-api</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.logging.log4j</groupId>
+            <artifactId>log4j-core</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.logging.log4j</groupId>
+            <artifactId>log4j-slf4j-impl</artifactId>
         </dependency>
         <dependency>
             <groupId>dk.brics.automaton</groupId>

--- a/oscar4-tokeniser/pom.xml
+++ b/oscar4-tokeniser/pom.xml
@@ -28,9 +28,17 @@
         </dependency>
 
         <dependency>
-            <groupId>org.slf4j</groupId>
-            <artifactId>slf4j-api</artifactId>
+            <groupId>org.apache.logging.log4j</groupId>
+            <artifactId>log4j-api</artifactId>
         </dependency>
+        <dependency>
+            <groupId>org.apache.logging.log4j</groupId>
+            <artifactId>log4j-core</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.logging.log4j</groupId>
+            <artifactId>log4j-slf4j-impl</artifactId>
+         </dependency>
 
 		<dependency>
 			<groupId>junit</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -62,7 +62,7 @@
 		<opsin-core.version>2.5.0</opsin-core.version>
 		<opsin-inchi.version>${opsin-core.version}</opsin-inchi.version>
 		<xom.version>1.3.7</xom.version>
-		<log4j2.version>2.17.0</log4j2.version>
+		<log4j2.version>2.17.1</log4j2.version>
 		<icu4j.version>70.1</icu4j.version>
 		<poi.version>5.1.0</poi.version>
 		<opennlp-maxent.version>3.0.3</opennlp-maxent.version>

--- a/pom.xml
+++ b/pom.xml
@@ -68,9 +68,6 @@
 		<opennlp-maxent.version>3.0.3</opennlp-maxent.version>
 		<opennlp-tools.version>1.9.4</opennlp-tools.version>
 		<automaton.version>1.11-8</automaton.version>
-		<slf4j-api.version>1.7.32</slf4j-api.version>
-		<slf4j-simple.version>1.7.32</slf4j-simple.version>
-		<slf4j-log4j12.version>1.7.32</slf4j-log4j12.version>
 		<commons-lang.version>2.6</commons-lang.version>
 		<commons-io.version>2.11.0</commons-io.version>
 		<commons-discovery.version>20040218.194635</commons-discovery.version>
@@ -184,16 +181,21 @@
 				<artifactId>xom</artifactId>
 				<version>${xom.version}</version>
 			</dependency>
-			<dependency>
-				<groupId>org.slf4j</groupId>
-				<artifactId>slf4j-log4j12</artifactId>
-				<version>${slf4j-log4j12.version}</version>
+                        <dependency>
+                                <groupId>org.apache.logging.log4j</groupId>
+                                <artifactId>log4j-api</artifactId>
+                                <version>${log4j2.version}</version>
 			</dependency>
-			<dependency>
-				<groupId>org.apache.logging.log4j</groupId>
-				<artifactId>log4j-1.2-api</artifactId>
-				<version>${log4j2.version}</version>
-			</dependency>
+                        <dependency>
+                                <groupId>org.apache.logging.log4j</groupId>
+                                <artifactId>log4j-core</artifactId>
+                                <version>${log4j2.version}</version>
+                        </dependency>
+                        <dependency>
+                                <groupId>org.apache.logging.log4j</groupId>
+                                <artifactId>log4j-slf4j-impl</artifactId>
+                                <version>${log4j2.version}</version>
+                        </dependency>
 			<dependency>
 				<groupId>com.ibm.icu</groupId>
 				<artifactId>icu4j</artifactId>
@@ -218,16 +220,6 @@
 				<groupId>dk.brics.automaton</groupId>
 				<artifactId>automaton</artifactId>
 				<version>${automaton.version}</version>
-			</dependency>
-			<dependency>
-				<groupId>org.slf4j</groupId>
-				<artifactId>slf4j-api</artifactId>
-				<version>${slf4j-api.version}</version>
-			</dependency>
-			<dependency>
-				<groupId>org.slf4j</groupId>
-				<artifactId>slf4j-simple</artifactId>
-				<version>${slf4j-simple.version}</version>
 			</dependency>
 			<dependency>
 				<groupId>commons-lang</groupId>


### PR DESCRIPTION
SLF4J and the parent/child pom relationship was not being used correctly, and as a result, was falling back to a log4j1
version and not the log4j2 version as stated in the parent pom. This was caused by the following commit 2b99b895f .

Many thanks to Dr Adam Thorn <alt36@cam.ac.uk> @alt36 for spotting and investigating this.

This is why [this](https://github.com/BlueObelisk/oscar4/pull/8/commits/8c7643d158d1636ade41147f88873c097f7d52bf) PR "worked" with an non-existent log4j2 version; trying it now with that version will cause it to, correctly, fail.

If this is good, I will deploy 5.1.2 to Central.